### PR TITLE
[Fix] Update BUSD.e decimals for Avalanchec network 

### DIFF
--- a/blockchains/avalanchec/assets/0x19860CCB0A68fd4213aB9D8266F7bBf05A8dDe98/info.json
+++ b/blockchains/avalanchec/assets/0x19860CCB0A68fd4213aB9D8266F7bBf05A8dDe98/info.json
@@ -2,7 +2,7 @@
     "name": "Binance USD",
     "symbol": "BUSD.e",
     "type": "AVALANCHE",
-    "decimals": 6,
+    "decimals": 18,
     "description": "The Avalanche Bridge Wrapped Binance USD. BUSD is a dollar-backed stablecoin issued and custodied by Paxos Trust Company, and regulated by the New York State Department of Financial Services. BUSD is available directly for sale 1:1 with USD on Paxos.com and will be listed for trading on Binance.",
     "website": "http://www.paxos.com/busd",
     "explorer": "https://snowtrace.io/address/0x19860CCB0A68fd4213aB9D8266F7bBf05A8dDe98",

--- a/blockchains/avalanchec/tokenlist.json
+++ b/blockchains/avalanchec/tokenlist.json
@@ -279,7 +279,7 @@
             "address": "0x19860CCB0A68fd4213aB9D8266F7bBf05A8dDe98",
             "name": "Binance USD",
             "symbol": "BUSD.e",
-            "decimals": 6,
+            "decimals": 18,
             "logoURI": "https://assets-cdn.trustwallet.com/blockchains/avalanchec/assets/0x19860CCB0A68fd4213aB9D8266F7bBf05A8dDe98/logo.png",
             "pairs": []
         },


### PR DESCRIPTION
The BUSD.e token has 18 decimals and we're storing it here with 6 decimals, making our extension to show pretty weird numbers.